### PR TITLE
feat: 회원 관련 API 구현 및 CI 관련 워크플로우 추가

### DIFF
--- a/.github/workflows/master_cicd.yml
+++ b/.github/workflows/master_cicd.yml
@@ -1,4 +1,4 @@
-name: master 브랜치 자동 배포
+name: master 브랜치 merge 시 CI/CD 파이프라인
 
 on:
   push:
@@ -18,6 +18,15 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '21'
+
+      - name: AWS S3 관련 정보를 설정 파일에 주입
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/main/resources/application-prod.yml
+        env:
+          aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws.s3.accessKey: ${{ secrets.AWS_S3_ACCESS_KEY }}
+          aws.s3.secretKey: ${{ secrets.AWS_S3_SECRET_KEY }}
 
       - name: 빌드로 테스트 수행 및 Jar 파일 생성
         run: |

--- a/.github/workflows/pr_weekly_ci.yml
+++ b/.github/workflows/pr_weekly_ci.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+
     steps:
       - name: 프로젝트 코드를 CI 서버로 옮겨오기
         uses: actions/checkout@v4
@@ -32,7 +37,7 @@ jobs:
           chmod +x ./gradlew
           ./gradlew clean build
 
-      - name: Show test result
+      - name: 테스트 수행 결과 보고
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:

--- a/.github/workflows/pr_weekly_ci.yml
+++ b/.github/workflows/pr_weekly_ci.yml
@@ -1,0 +1,46 @@
+name: weekly 브랜치 PR에 대한 CI 테스트
+
+on:
+  pull_request:
+    branches:
+      - 'weekly/**'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 프로젝트 코드를 CI 서버로 옮겨오기
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+
+      - name: AWS S3 관련 정보를 설정 파일에 주입
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/main/resources/application-prod.yml
+        env:
+          aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET }}
+          aws.s3.accessKey: ${{ secrets.AWS_S3_ACCESS_KEY }}
+          aws.s3.secretKey: ${{ secrets.AWS_S3_SECRET_KEY }}
+
+      - name: 빌드 테스트 수행
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build
+
+      - name: Show test result
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: 테스트 실패 시, 실패한 코드 라인에 코멘트 자동 등록
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+application-dev.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.657'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.657'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/potatocake/everymoment/config/AwsS3Properties.java
+++ b/src/main/java/com/potatocake/everymoment/config/AwsS3Properties.java
@@ -1,0 +1,12 @@
+package com.potatocake.everymoment.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public record AwsS3Properties(
+        String accessKey,
+        String secretKey,
+        String region,
+        String bucket
+) {
+}

--- a/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
+++ b/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
@@ -46,12 +46,11 @@ public class SecurityConfig {
 
         http
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(new Http401Handler(objectMapper)));
+                        .authenticationEntryPoint(http401Handler()));
 
         http
-                .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class)
-                .addFilterAt(new LoginFilter(filterProcessesUrl, objectMapper, jwtUtil, memberRepository,
-                        authenticationManager()), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter(), LoginFilter.class)
+                .addFilterAt(loginFilter(), UsernamePasswordAuthenticationFilter.class);
 
         http
                 .sessionManagement(session -> session
@@ -68,6 +67,21 @@ public class SecurityConfig {
         provider.setPasswordEncoder(passwordEncoder());
 
         return new ProviderManager(provider);
+    }
+
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(jwtUtil);
+    }
+
+    @Bean
+    public LoginFilter loginFilter() {
+        return new LoginFilter(filterProcessesUrl, objectMapper, jwtUtil, memberRepository, authenticationManager());
+    }
+
+    @Bean
+    public Http401Handler http401Handler() {
+        return new Http401Handler(objectMapper);
     }
 
     @Bean

--- a/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
+++ b/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/login", "/h2-console/**", "/error").permitAll()
+                        .requestMatchers("/api/members/login", "/h2-console/**", "/error", "/favicon.ico").permitAll()
+                        .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 
         http

--- a/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
+++ b/src/main/java/com/potatocake/everymoment/config/SecurityConfig.java
@@ -46,11 +46,12 @@ public class SecurityConfig {
 
         http
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(http401Handler()));
+                        .authenticationEntryPoint(new Http401Handler(objectMapper)));
 
         http
-                .addFilterBefore(jwtFilter(), LoginFilter.class)
-                .addFilterAt(loginFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class)
+                .addFilterAt(new LoginFilter(filterProcessesUrl, objectMapper, jwtUtil, memberRepository,
+                        authenticationManager()), UsernamePasswordAuthenticationFilter.class);
 
         http
                 .sessionManagement(session -> session
@@ -67,21 +68,6 @@ public class SecurityConfig {
         provider.setPasswordEncoder(passwordEncoder());
 
         return new ProviderManager(provider);
-    }
-
-    @Bean
-    public JwtFilter jwtFilter() {
-        return new JwtFilter(jwtUtil);
-    }
-
-    @Bean
-    public LoginFilter loginFilter() {
-        return new LoginFilter(filterProcessesUrl, objectMapper, jwtUtil, memberRepository, authenticationManager());
-    }
-
-    @Bean
-    public Http401Handler http401Handler() {
-        return new Http401Handler(objectMapper);
     }
 
     @Bean

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -14,8 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -58,7 +58,7 @@ public class MemberController {
                 .body(SuccessResponse.ok(response));
     }
 
-    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SuccessResponse<Void>> updateMemberInfo(@AuthenticationPrincipal MemberDetails memberDetails,
                                                                   @RequestParam(required = false) MultipartFile profileImage,
                                                                   @RequestParam(required = false) String nickname) {

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -4,16 +4,22 @@ import com.potatocake.everymoment.dto.SuccessResponse;
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
 import com.potatocake.everymoment.dto.response.MemberResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.exception.ErrorCode;
+import com.potatocake.everymoment.exception.GlobalException;
 import com.potatocake.everymoment.security.MemberDetails;
 import com.potatocake.everymoment.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -50,6 +56,24 @@ public class MemberController {
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.ok(response));
+    }
+
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SuccessResponse<Void>> updateMemberInfo(@AuthenticationPrincipal MemberDetails memberDetails,
+                                                                  @RequestParam(required = false) MultipartFile profileImage,
+                                                                  @RequestParam(required = false) String nickname) {
+        validateProfileUpdate(profileImage, nickname);
+
+        memberService.updateMemberInfo(memberDetails.getId(), profileImage, nickname);
+
+        return ResponseEntity.ok()
+                .body(SuccessResponse.ok());
+    }
+
+    private void validateProfileUpdate(MultipartFile profileImage, String nickname) {
+        if (profileImage == null && !StringUtils.hasText(nickname)) {
+            throw new GlobalException(ErrorCode.INFO_REQUIRED);
+        }
     }
 
 }

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.potatocake.everymoment.controller;
 
 import com.potatocake.everymoment.dto.SuccessResponse;
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
+import com.potatocake.everymoment.dto.response.MemberResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
 import com.potatocake.everymoment.security.MemberDetails;
 import com.potatocake.everymoment.service.MemberService;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,6 +39,14 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<MemberDetailResponse>> myInfo(
             @AuthenticationPrincipal MemberDetails memberDetails) {
         MemberDetailResponse response = memberService.getMyInfo(memberDetails.getId());
+
+        return ResponseEntity.ok()
+                .body(SuccessResponse.ok(response));
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<SuccessResponse<MemberResponse>> memberInfo(@PathVariable Long memberId) {
+        MemberResponse response = memberService.getMemberInfo(memberId);
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.ok(response));

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -1,10 +1,13 @@
 package com.potatocake.everymoment.controller;
 
 import com.potatocake.everymoment.dto.SuccessResponse;
+import com.potatocake.everymoment.dto.response.MemberDetailResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.security.MemberDetails;
 import com.potatocake.everymoment.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,6 +28,15 @@ public class MemberController {
             @RequestParam(defaultValue = "10") int size) {
 
         MemberSearchResponse response = memberService.searchMembers(nickname, email, key, size);
+
+        return ResponseEntity.ok()
+                .body(SuccessResponse.ok(response));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<SuccessResponse<MemberDetailResponse>> myInfo(
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+        MemberDetailResponse response = memberService.getMyInfo(memberDetails.getId());
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.ok(response));

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.potatocake.everymoment.controller;
+
+import com.potatocake.everymoment.dto.SuccessResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<MemberSearchResponse>> searchMembers(
+            @RequestParam(required = false) String nickname,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) Long key,
+            @RequestParam(defaultValue = "10") int size) {
+
+        MemberSearchResponse response = memberService.searchMembers(nickname, email, key, size);
+
+        return ResponseEntity.ok()
+                .body(SuccessResponse.ok(response));
+    }
+
+}

--- a/src/main/java/com/potatocake/everymoment/dto/SuccessResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/SuccessResponse.java
@@ -14,8 +14,17 @@ public class SuccessResponse<T> {
     private String message;
     private T info;
 
-    public static <T> SuccessResponse of(T info) {
+    public static <T> SuccessResponse of(int code, T info) {
         return SuccessResponse.builder()
+                .code(code)
+                .message("success")
+                .info(info)
+                .build();
+    }
+
+    public static <T> SuccessResponse ok(T info) {
+        return SuccessResponse.builder()
+                .code(200)
                 .message("success")
                 .info(info)
                 .build();

--- a/src/main/java/com/potatocake/everymoment/dto/SuccessResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/SuccessResponse.java
@@ -30,4 +30,11 @@ public class SuccessResponse<T> {
                 .build();
     }
 
+    public static <T> SuccessResponse ok() {
+        return SuccessResponse.builder()
+                .code(200)
+                .message("success")
+                .build();
+    }
+
 }

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberDetailResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberDetailResponse.java
@@ -1,0 +1,15 @@
+package com.potatocake.everymoment.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberDetailResponse {
+
+    private Long id;
+    private String profileImageUrl;
+    private String nickname;
+    private String email;
+
+}

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberResponse.java
@@ -1,0 +1,14 @@
+package com.potatocake.everymoment.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String profileImageUrl;
+    private String nickname;
+
+}

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResponse.java
@@ -1,0 +1,16 @@
+package com.potatocake.everymoment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+@Getter
+public class MemberSearchResponse {
+
+    private List<MemberResponse> members;
+    private Long next;
+
+}

--- a/src/main/java/com/potatocake/everymoment/entity/Member.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Member.java
@@ -32,4 +32,9 @@ public class Member extends BaseTimeEntity {
     @Lob
     private String profileImageUrl;
 
+    public void update(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
 }

--- a/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
+++ b/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
     UNKNOWN_ERROR("알 수 없는 오류가 발생했습니다.", INTERNAL_SERVER_ERROR),
 
     LOGIN_FAILED("로그인에 실패했습니다.", UNAUTHORIZED),
-    LOGIN_REQUIRED("유효한 인증 정보가 필요합니다.", UNAUTHORIZED);
+    LOGIN_REQUIRED("유효한 인증 정보가 필요합니다.", UNAUTHORIZED),
+
+    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
+++ b/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.potatocake.everymoment.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -37,7 +38,7 @@ public enum ErrorCode {
     INVALID_FILE_TYPE("이미지 파일 형식만 첨부가 가능합니다. (JPEG, PNG)", UNSUPPORTED_MEDIA_TYPE),
     FILE_STORE_FAILED("파일 저장에 실패했습니다.", INTERNAL_SERVER_ERROR),
 
-    INFO_REQUIRED("정보를 입력해 주세요.", CONFLICT);
+    INFO_REQUIRED("정보를 입력해 주세요.", BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
+++ b/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -20,7 +21,7 @@ public enum ErrorCode {
 
     /* File */
     FILE_NOT_FOUND("존재하지 않는 파일입니다.", NOT_FOUND),
-    FILE_SIZE_EXCEEDED("전체 파일 크기를 10MB 이하로 첨부해 주세요.", PAYLOAD_TOO_LARGE),
+    FILE_SIZE_EXCEEDED("각 파일은 1MB 이하로, 전체 파일 크기는 10MB 이하로 첨부해 주세요.", PAYLOAD_TOO_LARGE),
 
     /* Comment */
     COMMENT_NOT_FOUND("존재하지 않는 댓글입니다.", NOT_FOUND),
@@ -30,7 +31,13 @@ public enum ErrorCode {
     LOGIN_FAILED("로그인에 실패했습니다.", UNAUTHORIZED),
     LOGIN_REQUIRED("유효한 인증 정보가 필요합니다.", UNAUTHORIZED),
 
-    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", NOT_FOUND);
+    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", NOT_FOUND),
+
+    /* S3FileUploader */
+    INVALID_FILE_TYPE("이미지 파일 형식만 첨부가 가능합니다. (JPEG, PNG)", UNSUPPORTED_MEDIA_TYPE),
+    FILE_STORE_FAILED("파일 저장에 실패했습니다.", INTERNAL_SERVER_ERROR),
+
+    INFO_REQUIRED("정보를 입력해 주세요.", CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/potatocake/everymoment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/potatocake/everymoment/exception/GlobalExceptionHandler.java
@@ -1,5 +1,9 @@
 package com.potatocake.everymoment.exception;
 
+import static com.potatocake.everymoment.exception.ErrorCode.FILE_SIZE_EXCEEDED;
+import static com.potatocake.everymoment.exception.ValidationErrorMessage.VALIDATION_ERROR;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -8,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -16,15 +22,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> invalid(MethodArgumentNotValidException e) {
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .code(400)
-                .message(ValidationErrorMessage.VALIDATION_ERROR)
-                .build();
+        ErrorResponse errorResponse = getErrorResponse(400, VALIDATION_ERROR);
 
         e.getFieldErrors().forEach(filedError ->
                 errorResponse.addValidation(filedError.getField(), filedError.getDefaultMessage()));
 
         return ResponseEntity.badRequest()
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> missingRequestPart(MissingServletRequestPartException e) {
+        ErrorResponse errorResponse = getErrorResponse(400, e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> fileMaxSize() {
+        ErrorResponse errorResponse = getErrorResponse(PAYLOAD_TOO_LARGE.value(), FILE_SIZE_EXCEEDED.getMessage());
+
+        return ResponseEntity.status(PAYLOAD_TOO_LARGE)
                 .body(errorResponse);
     }
 

--- a/src/main/java/com/potatocake/everymoment/repository/MemberRepository.java
+++ b/src/main/java/com/potatocake/everymoment/repository/MemberRepository.java
@@ -2,6 +2,9 @@ package com.potatocake.everymoment.repository;
 
 import com.potatocake.everymoment.entity.Member;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -9,5 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Window<Member> findByNicknameContainingAndEmailContaining(String nickname, String email, ScrollPosition position,
+                                                              Pageable pageable);
 
 }

--- a/src/main/java/com/potatocake/everymoment/security/MemberDetails.java
+++ b/src/main/java/com/potatocake/everymoment/security/MemberDetails.java
@@ -34,4 +34,8 @@ public class MemberDetails implements UserDetails {
         return member.getEmail();
     }
 
+    public Long getId() {
+        return member.getId();
+    }
+
 }

--- a/src/main/java/com/potatocake/everymoment/security/filter/JwtFilter.java
+++ b/src/main/java/com/potatocake/everymoment/security/filter/JwtFilter.java
@@ -12,13 +12,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -30,7 +28,6 @@ public class JwtFilter extends OncePerRequestFilter {
         Optional<String> token = jwtUtil.resolveToken(request);
 
         if (token.isEmpty() || jwtUtil.isExpired(token.get())) {
-            log.info("인증 실패 - 토큰 없음 또는 만료됨");
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/potatocake/everymoment/security/filter/LoginFilter.java
+++ b/src/main/java/com/potatocake/everymoment/security/filter/LoginFilter.java
@@ -70,7 +70,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         JwtResponse jwt = JwtResponse.of(token);
 
-        objectMapper.writeValue(response.getWriter(), SuccessResponse.of(jwt));
+        objectMapper.writeValue(response.getWriter(), SuccessResponse.ok(jwt));
     }
 
     @Override

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -37,6 +37,31 @@ public class MemberService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public MemberDetailResponse getMyInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberDetailResponse.builder()
+                .id(member.getId())
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResponse getMemberInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberResponse.builder()
+                .id(member.getId())
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .build();
+    }
+
     private Window<Member> fetchMemberWindow(String nickname, String email, Long key, int size) {
         ScrollPosition scrollPosition = pagingUtil.createScrollPosition(key);
         Pageable pageable = pagingUtil.createPageable(size);
@@ -56,18 +81,6 @@ public class MemberService {
                         .nickname(member.getNickname())
                         .build())
                 .collect(Collectors.toList());
-    }
-
-    public MemberDetailResponse getMyInfo(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
-
-        return MemberDetailResponse.builder()
-                .id(member.getId())
-                .profileImageUrl(member.getProfileImageUrl())
-                .nickname(member.getNickname())
-                .email(member.getEmail())
-                .build();
     }
 
 }

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -1,0 +1,58 @@
+package com.potatocake.everymoment.service;
+
+import com.potatocake.everymoment.dto.response.MemberResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.entity.Member;
+import com.potatocake.everymoment.repository.MemberRepository;
+import com.potatocake.everymoment.util.PagingUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PagingUtil pagingUtil;
+
+    @Transactional(readOnly = true)
+    public MemberSearchResponse searchMembers(String nickname, String email, Long key, int size) {
+        Window<Member> window = fetchMemberWindow(nickname, email, key, size);
+        List<MemberResponse> members = convertToMemberResponses(window.getContent());
+        Long nextKey = pagingUtil.getNextKey(window);
+
+        return MemberSearchResponse.builder()
+                .members(members)
+                .next(nextKey)
+                .build();
+    }
+
+    private Window<Member> fetchMemberWindow(String nickname, String email, Long key, int size) {
+        ScrollPosition scrollPosition = pagingUtil.createScrollPosition(key);
+        Pageable pageable = pagingUtil.createPageable(size);
+
+        String searchNickname = (nickname == null) ? "" : nickname;
+        String searchEmail = (email == null) ? "" : email;
+
+        return memberRepository.findByNicknameContainingAndEmailContaining(searchNickname, searchEmail, scrollPosition,
+                pageable);
+    }
+
+    private List<MemberResponse> convertToMemberResponses(List<Member> members) {
+        return members.stream()
+                .map(member -> MemberResponse.builder()
+                        .id(member.getId())
+                        .profileImageUrl(member.getProfileImageUrl())
+                        .nickname(member.getNickname())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -1,8 +1,11 @@
 package com.potatocake.everymoment.service;
 
+import com.potatocake.everymoment.dto.response.MemberDetailResponse;
 import com.potatocake.everymoment.dto.response.MemberResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
 import com.potatocake.everymoment.entity.Member;
+import com.potatocake.everymoment.exception.ErrorCode;
+import com.potatocake.everymoment.exception.GlobalException;
 import com.potatocake.everymoment.repository.MemberRepository;
 import com.potatocake.everymoment.util.PagingUtil;
 import java.util.List;
@@ -53,6 +56,18 @@ public class MemberService {
                         .nickname(member.getNickname())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public MemberDetailResponse getMyInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberDetailResponse.builder()
+                .id(member.getId())
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .build();
     }
 
 }

--- a/src/main/java/com/potatocake/everymoment/util/PagingUtil.java
+++ b/src/main/java/com/potatocake/everymoment/util/PagingUtil.java
@@ -1,0 +1,29 @@
+package com.potatocake.everymoment.util;
+
+import com.potatocake.everymoment.entity.Member;
+import java.util.Map;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Window;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PagingUtil {
+
+    public ScrollPosition createScrollPosition(Long key) {
+        return key == null ? ScrollPosition.offset() : ScrollPosition.forward(Map.of("id", key));
+    }
+
+    public Pageable createPageable(int size) {
+        return PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "id"));
+    }
+
+    public Long getNextKey(Window<?> window) {
+        return window.hasNext()
+                ? ((Member) window.getContent().get(window.getContent().size() - 1)).getId()
+                : null;
+    }
+
+}

--- a/src/main/java/com/potatocake/everymoment/util/S3FileUploader.java
+++ b/src/main/java/com/potatocake/everymoment/util/S3FileUploader.java
@@ -1,0 +1,70 @@
+package com.potatocake.everymoment.util;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.potatocake.everymoment.config.AwsS3Properties;
+import com.potatocake.everymoment.exception.ErrorCode;
+import com.potatocake.everymoment.exception.GlobalException;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@EnableConfigurationProperties(AwsS3Properties.class)
+@Component
+public class S3FileUploader {
+
+    private AmazonS3 amazonS3;
+    private final AwsS3Properties properties;
+
+    @PostConstruct
+    private void s3Client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(properties.accessKey(), properties.secretKey());
+
+        amazonS3 = AmazonS3ClientBuilder.standard()
+                .withRegion(properties.region())
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    public String uploadFile(MultipartFile file) {
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        try {
+            validateFileType(file);
+
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(file.getContentType());
+            objectMetadata.setContentLength(file.getSize());
+
+            amazonS3.putObject(
+                    new PutObjectRequest(properties.bucket(), filename, file.getInputStream(), objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new GlobalException(ErrorCode.FILE_STORE_FAILED);
+        }
+
+        return amazonS3.getUrl(properties.bucket(), filename).toString();
+    }
+
+    private void validateFileType(MultipartFile file) throws IOException {
+        String fileType = file.getContentType();
+
+        if (fileType == null || (!fileType.equals(MediaType.IMAGE_JPEG_VALUE) && !fileType.equals(
+                MediaType.IMAGE_PNG_VALUE))) {
+            throw new GlobalException(ErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+  h2:
+    console:
+      enabled: true
+
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 10MB
+      resolve-lazily: true
+
+aws:
+  s3:
+    client: AmazonS3
+    region: ap-northeast-2
+    bucket: ${AWS_S3_BUCKET}
+    accessKey: ${AWS_S3_ACCESS_KEY}
+    secretKey: ${AWS_S3_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,15 +1,3 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-
-  jpa:
-    properties:
-      hibernate:
-        format_sql: true
-    show-sql: true
-
-  h2:
-    console:
-      enabled: true
+  profiles:
+    active: prod

--- a/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
+++ b/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
@@ -1,0 +1,183 @@
+package com.potatocake.everymoment.controller;
+
+import static com.potatocake.everymoment.exception.ErrorCode.INFO_REQUIRED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.potatocake.everymoment.dto.response.MemberDetailResponse;
+import com.potatocake.everymoment.dto.response.MemberResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.entity.Member;
+import com.potatocake.everymoment.security.MemberDetails;
+import com.potatocake.everymoment.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.multipart.MultipartFile;
+
+@WithMockUser
+@AutoConfigureMockMvc
+@SpringBootTest
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원 목록 검색이 성공적으로 수행된다.")
+    void should_SearchMembers_When_ValidInput() throws Exception {
+        // given
+        String nickname = "testUser";
+        String email = "test@test.com";
+        Long key = 1L;
+        int size = 10;
+        MemberSearchResponse response = MemberSearchResponse.builder().build();
+
+        given(memberService.searchMembers(nickname, email, key, size)).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/members")
+                .param("nickname", nickname)
+                .param("email", email)
+                .param("key", key.toString())
+                .param("size", String.valueOf(size)));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        then(memberService).should().searchMembers(nickname, email, key, size);
+    }
+
+    @Test
+    @DisplayName("내 정보 조회가 성공적으로 수행된다.")
+    void should_ReturnMyInfo_When_ValidMember() throws Exception {
+        // given
+        Long memberId = 1L;
+        MemberDetails memberDetails = createMemberDetails(memberId, "test@example.com", "test");
+
+        MemberDetailResponse response = MemberDetailResponse.builder().build();
+        given(memberService.getMyInfo(memberId)).willReturn(response);
+
+        // when
+        ResultActions result = performGet("/api/members/me", memberDetails);
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.info").isNotEmpty());
+
+        then(memberService).should().getMyInfo(memberId);
+    }
+
+    @Test
+    @DisplayName("회원 ID로 정보 조회가 성공적으로 수행된다.")
+    void should_ReturnMemberInfo_When_ValidMemberId() throws Exception {
+        // given
+        Long memberId = 1L;
+        MemberResponse response = MemberResponse.builder().build();
+
+        given(memberService.getMemberInfo(memberId)).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/members/{memberId}", memberId));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.info").isNotEmpty());
+
+        then(memberService).should().getMemberInfo(memberId);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정이 성공적으로 수행된다.")
+    void should_UpdateMemberInfo_When_ValidInput() throws Exception {
+        // given
+        Long memberId = 1L;
+        MemberDetails memberDetails = createMemberDetails(memberId, "test@example.com", "test");
+
+        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "image.png", "image/png", new byte[]{});
+        String nickname = "newNickname";
+
+        willDoNothing().given(memberService).updateMemberInfo(anyLong(), any(MultipartFile.class), anyString());
+
+        // when
+        ResultActions result = performMultipart("/api/members", profileImage, nickname, memberDetails);
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        then(memberService).should().updateMemberInfo(memberId, profileImage, nickname);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지와 닉네임이 모두 누락되면 예외가 발생한다.")
+    void should_ThrowException_When_ProfileImageAndNicknameAreMissing() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(multipart("/api/members"));
+
+        // then
+        result
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(INFO_REQUIRED.getStatus().value()))
+                .andExpect(jsonPath("$.message").value(INFO_REQUIRED.getMessage()));
+
+        then(memberService).shouldHaveNoInteractions();
+    }
+
+    private Member createMember(Long memberId, String email, String nickname) {
+        return Member.builder()
+                .id(memberId)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
+
+    private MemberDetails createMemberDetails(Long memberId, String email, String nickname) {
+        Member member = createMember(memberId, email, nickname);
+        return new MemberDetails(member);
+    }
+
+    private ResultActions performGet(String url, MemberDetails memberDetails) throws Exception {
+        return mockMvc.perform(get(url)
+                .with(user(memberDetails)));
+    }
+
+    private ResultActions performMultipart(String url, MockMultipartFile file, String nickname,
+                                           MemberDetails memberDetails) throws Exception {
+        return mockMvc.perform(multipart(url)
+                .file(file)
+                .param("nickname", nickname)
+                .with(user(memberDetails)));
+    }
+
+}

--- a/src/test/java/com/potatocake/everymoment/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/potatocake/everymoment/repository/MemberRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.potatocake.everymoment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.potatocake.everymoment.entity.Member;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("이메일로 회원을 성공적으로 조회한다.")
+    void should_FindMemberByEmail_When_EmailExists() {
+        // given
+        String email = "test@test.com";
+        memberRepository.save(Member.builder()
+                .email(email)
+                .nickname("testUser")
+                .build());
+
+        // when
+        Optional<Member> foundMember = memberRepository.findByEmail(email);
+
+        // then
+        assertThat(foundMember).isPresent();
+        assertThat(foundMember.get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("이메일이 존재하는지 확인한다.")
+    void should_ReturnTrue_When_EmailExists() {
+        // given
+        String email = "test@test.com";
+        memberRepository.save(Member.builder()
+                .email(email)
+                .nickname("testUser")
+                .build());
+
+        // when
+        boolean exists = memberRepository.existsByEmail(email);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("닉네임과 이메일을 포함하여 스크롤 방식으로 회원 목록을 조회한다.")
+    void should_FindByNicknameContainingAndEmailContaining_When_ValidScrollPosition() {
+        // given
+        String nickname = "test";
+        String email = "test";
+        for (int i = 1; i <= 15; i++) {
+            memberRepository.save(Member.builder()
+                    .nickname(nickname + i)
+                    .email(email + i + "@test.com")
+                    .build());
+        }
+
+        // when
+        ScrollPosition scrollPosition = ScrollPosition.offset();
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        Window<Member> window = memberRepository.findByNicknameContainingAndEmailContaining(nickname, email,
+                scrollPosition, pageRequest);
+
+        // then
+        assertThat(window).isNotNull();
+        assertThat(window.getContent().size()).isEqualTo(10);
+        assertThat(window.hasNext()).isTrue(); // 총 15개 중 10개를 조회했으므로 다음 페이지 존재
+    }
+
+    @Test
+    @DisplayName("닉네임과 이메일이 일치하지 않으면 빈 결과를 반환한다.")
+    void should_ReturnEmpty_When_NoMatchingNicknameAndEmail() {
+        // given
+        ScrollPosition scrollPosition = ScrollPosition.offset();
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // when
+        Window<Member> window = memberRepository.findByNicknameContainingAndEmailContaining("nonexistent",
+                "nonexistent@test.com", scrollPosition, pageRequest);
+
+        // then
+        assertThat(window.getContent()).isEmpty();
+    }
+
+}

--- a/src/test/java/com/potatocake/everymoment/service/MemberServiceTest.java
+++ b/src/test/java/com/potatocake/everymoment/service/MemberServiceTest.java
@@ -1,0 +1,120 @@
+package com.potatocake.everymoment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.potatocake.everymoment.dto.response.MemberDetailResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.entity.Member;
+import com.potatocake.everymoment.exception.GlobalException;
+import com.potatocake.everymoment.repository.MemberRepository;
+import com.potatocake.everymoment.util.PagingUtil;
+import com.potatocake.everymoment.util.S3FileUploader;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PagingUtil pagingUtil;
+
+    @Mock
+    private S3FileUploader s3FileUploader;
+
+    @Test
+    @DisplayName("회원 목록 검색이 성공적으로 수행된다.")
+    void should_ReturnMemberList_When_ValidSearchConditions() {
+        // given
+        String nickname = "testUser";
+        String email = "test@test.com";
+        Long key = 1L;
+        int size = 10;
+
+        List<Member> members = List.of(Member.builder().build());
+        Window<Member> window = Window.from(members, ScrollPosition::offset, false);
+        given(memberRepository.findByNicknameContainingAndEmailContaining(anyString(), anyString(), any(), any()))
+                .willReturn(window);
+
+        // when
+        MemberSearchResponse result = memberService.searchMembers(nickname, email, key, size);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMembers()).isNotEmpty();
+
+        then(memberRepository).should()
+                .findByNicknameContainingAndEmailContaining(anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    @DisplayName("내 정보 조회가 성공적으로 수행된다.")
+    void should_ReturnMyInfo_When_ValidMemberId() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder().build();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        MemberDetailResponse result = memberService.getMyInfo(memberId);
+
+        // then
+        assertThat(result).isNotNull();
+
+        then(memberRepository).should().findById(memberId);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정이 성공적으로 수행된다.")
+    void should_UpdateMemberInfo_When_ValidInput() {
+        // given
+        Long memberId = 1L;
+        MultipartFile profileImage = mock(MultipartFile.class);
+        String nickname = "newNickname";
+
+        Member member = Member.builder().build();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(s3FileUploader.uploadFile(profileImage)).willReturn("profileUrl");
+
+        // when
+        memberService.updateMemberInfo(memberId, profileImage, nickname);
+
+        // then
+        assertThat(member.getNickname()).isEqualTo("newNickname");
+
+        then(memberRepository).should().findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 정보를 수정하려고 하면 예외가 발생한다.")
+    void should_ThrowException_When_MemberNotFound() {
+        // given
+        Long memberId = 1L;
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatExceptionOfType(GlobalException.class)
+                .isThrownBy(() -> memberService.updateMemberInfo(memberId, null, "newNickname"));
+    }
+
+}

--- a/src/test/java/com/potatocake/everymoment/util/PagingUtilTest.java
+++ b/src/test/java/com/potatocake/everymoment/util/PagingUtilTest.java
@@ -1,0 +1,74 @@
+package com.potatocake.everymoment.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.potatocake.everymoment.entity.Member;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Window;
+
+class PagingUtilTest {
+
+    private PagingUtil pagingUtil;
+
+    @BeforeEach
+    void setUp() {
+        pagingUtil = new PagingUtil();
+    }
+
+    @Test
+    @DisplayName("스크롤 위치가 성공적으로 생성된다.")
+    void should_CreateScrollPosition_When_KeyIsNull() {
+        // when
+        ScrollPosition position = pagingUtil.createScrollPosition(null);
+
+        // then
+        Assertions.assertThat(position).isNotNull();
+    }
+
+    @Test
+    @DisplayName("페이지 정보가 성공적으로 생성된다.")
+    void should_CreatePageable_When_ValidSizeProvided() {
+        // when
+        Pageable pageable = pagingUtil.createPageable(10);
+
+        // then
+        assertThat(pageable).isNotNull();
+        assertThat(pageable.getPageSize()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("다음 페이지 키가 성공적으로 반환된다.")
+    void should_ReturnNextKey_When_WindowHasNext() {
+        // given
+        List<Member> members = List.of(Member.builder().id(1L).build());
+        Window<Member> window = Window.from(members, ScrollPosition::offset, true);
+
+        // when
+        Long nextKey = pagingUtil.getNextKey(window);
+
+        // then
+        assertThat(nextKey).isNotNull();
+        assertThat(nextKey).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("다음 페이지가 존재하지 않을 때, 키 값으로 null 을 반환한다.")
+    void should_ReturnNull_When_WindowHasNoNext() {
+        // given
+        List<Member> members = List.of(Member.builder().id(1L).build());
+        Window<Member> window = Window.from(members, ScrollPosition::offset, false);
+
+        // when
+        Long nextKey = pagingUtil.getNextKey(window);
+
+        // then
+        assertThat(nextKey).isNull();
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용

### 1. 회원 관련 API 구현 및 테스트 코드 작성
* 회원 검색 API
* 내 정보 조회 API
* 특정 회원 정보 조회 API
* 회원 정보 수정 API
* 회원 컨트롤러/서비스/리파지토리 및 `PagingUtil` 테스트 코드 작성

### 2. Weekly PR 시 자동 CI 테스트 워크플로우 추가
* 자동 CI 테스트 및 실패 지점까지 자동으로 코멘트
* 기존 CI/CD 자동 배포와는 다른 파일로 분리

### 3. SuccessResponse 편의 메서드 추가

![image](https://github.com/user-attachments/assets/b7619b69-3c81-4b06-8b33-344fe45586a5)

현재 SuccessResponse 생성 코드가 너무 반복되고 있어, 메서드 추가해 두었습니다.
**`code`** 가 200이 아니고 **`info`** 응답이 필요하다면 맨 위 메서드,
**`code`** 가 200이고, **`info`** 응답이 필요하다면 가운데 메서드, 필요 없다면 아래 메서드를 사용해 주시면 됩니다!

### 4. 환경별 설정 파일 분리

![image](https://github.com/user-attachments/assets/6ab26050-dfe1-4c16-95f7-1a7ff6d33bfe)

파일은 이렇게 dev와 prod(운영) 환경으로 나눴습니다
dev에는 민감한 정보도 담겨 있어서 .gitignore에 등록해두었습니다
기존 `application.yml`은 제거해 주시고, 아래와 같이 `application-dev.yml`을 따로 만들어 주세요!

```yaml
spring:
  datasource:
    url: jdbc:h2:mem:testdb
    username: sa
    password:

  jpa:
    properties:
      hibernate:
        format_sql: true
    show-sql: true

  h2:
    console:
      enabled: true

aws:
  s3:
    client: AmazonS3
    region: ap-northeast-2
    bucket: secret
    accessKey: secret
    secretKey: secret
```

secret에 관한 정보는 따로 드리겠습니다!

그리고, 기본 액티브 프로파일이 prod라서 서버 기동 시 오류가 발생할 텐데 아래와 같이 설정해 주세요

![image](https://github.com/user-attachments/assets/3d270a51-d4fc-4e9e-8d7c-a40f6e1fcc61)

![image](https://github.com/user-attachments/assets/2f43b3e2-c0be-43d3-9b1f-753e74286c5f)
 
### 5. 페이징 관련
저는 커서 기반 페이징을 저번에 코드리뷰 드렸을 때의 Spring Data JPA의 [Scrolling using Keyset-Filtering 방식](https://yeongunheo.tistory.com/entry/SpringBoot-%EC%8A%A4%ED%81%AC%EB%A1%A4-API-Offset-vs-Keyset-Filtering)으로 작업을 진행했는데,
페이징 작업이 계속 반복될 것 같아서 `PagingUtil` 이라는 클래스를 만들어 두었습니다.
이 방식도 한번 고려해 주세요!

## 🔗 관련 이슈
close #19 

