### PR TITLE
feat: 중복된 enum 제거 및 weekly 브랜치 병합 시 CI/CD 트리거 추가

### DIFF
--- a/.github/workflows/master_weekly_cicd.yml
+++ b/.github/workflows/master_weekly_cicd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'weekly/**'
 
 jobs:
   deploy:

--- a/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
+++ b/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
@@ -41,8 +41,6 @@ public enum ErrorCode {
     LOGIN_FAILED("로그인에 실패했습니다.", UNAUTHORIZED),
     LOGIN_REQUIRED("유효한 인증 정보가 필요합니다.", UNAUTHORIZED),
 
-    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", NOT_FOUND),
-
     /* S3FileUploader */
     INVALID_FILE_TYPE("이미지 파일 형식만 첨부가 가능합니다. (JPEG, PNG)", UNSUPPORTED_MEDIA_TYPE),
     FILE_STORE_FAILED("파일 저장에 실패했습니다.", INTERNAL_SERVER_ERROR),


### PR DESCRIPTION
## 📝 작업 내용
* 이미 존재하는 enum 제거
* weekly 브랜치 병합 시에도 CI/CD 워크플로우 동작

## 🔗 관련 이슈
close #22 

