### PR TITLE
fix: 회원 정보 수정 API 에러 해결

### DIFF
--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -97,7 +97,10 @@ public class MemberController {
     }
 
     private void validateProfileUpdate(MultipartFile profileImage, String nickname) {
-        if (profileImage == null && !StringUtils.hasText(nickname)) {
+        boolean isProfileImageEmpty = profileImage == null || profileImage.isEmpty();
+        boolean isNicknameEmpty = !StringUtils.hasText(nickname);
+        
+        if (isProfileImageEmpty && isNicknameEmpty) {
             throw new GlobalException(ErrorCode.INFO_REQUIRED);
         }
     }

--- a/src/main/java/com/potatocake/everymoment/entity/Member.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Member.java
@@ -1,5 +1,7 @@
 package com.potatocake.everymoment.entity;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,8 +42,12 @@ public class Member extends BaseTimeEntity {
     private boolean deleted = false;
 
     public void update(String nickname, String profileImageUrl) {
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
+        if (hasText(nickname)) {
+            this.nickname = nickname;
+        }
+        if (profileImageUrl != null) {
+            this.profileImageUrl = profileImageUrl;
+        }
     }
 
 }

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -70,7 +70,10 @@ public class MemberService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
-        String profileImageUrl = s3FileUploader.uploadFile(profileImage);
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = s3FileUploader.uploadFile(profileImage);
+        }
 
         member.update(nickname, profileImageUrl);
     }
@@ -78,7 +81,7 @@ public class MemberService {
     public void deleteMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
-        
+
         memberRepository.delete(member);
     }
 


### PR DESCRIPTION
## 📝 작업 내용
회원 정보 수정 시 닉네임, 프로필 이미지를 입력 받는데, 둘 중 하나가 null일 경우에 대한 처리가 없어 에러 발생
* nickname 혹은 profileImage 둘 중 하나만 null인 경우에 대한 처리 추가

## 🔗 관련 이슈
close #43 
