### PR TITLE
feat: 사용자 검색 시 친구 요청 상태 추가

### DIFF
--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -51,9 +51,10 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<MemberSearchResponse>> searchMembers(
             @RequestParam(required = false) String nickname,
             @RequestParam(required = false) Long key,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
 
-        MemberSearchResponse response = memberService.searchMembers(nickname, key, size);
+        MemberSearchResponse response = memberService.searchMembers(nickname, key, size, memberDetails.getId());
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.ok(response));

--- a/src/main/java/com/potatocake/everymoment/controller/MemberController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/MemberController.java
@@ -4,7 +4,7 @@ import com.potatocake.everymoment.dto.SuccessResponse;
 import com.potatocake.everymoment.dto.request.MemberLoginRequest;
 import com.potatocake.everymoment.dto.response.JwtResponse;
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
-import com.potatocake.everymoment.dto.response.MemberResponse;
+import com.potatocake.everymoment.dto.response.MemberMyResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
 import com.potatocake.everymoment.exception.ErrorCode;
 import com.potatocake.everymoment.exception.GlobalException;
@@ -69,8 +69,8 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<SuccessResponse<MemberResponse>> memberInfo(@PathVariable Long memberId) {
-        MemberResponse response = memberService.getMemberInfo(memberId);
+    public ResponseEntity<SuccessResponse<MemberMyResponse>> memberInfo(@PathVariable Long memberId) {
+        MemberMyResponse response = memberService.getMemberInfo(memberId);
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.ok(response));
@@ -99,7 +99,7 @@ public class MemberController {
     private void validateProfileUpdate(MultipartFile profileImage, String nickname) {
         boolean isProfileImageEmpty = profileImage == null || profileImage.isEmpty();
         boolean isNicknameEmpty = !StringUtils.hasText(nickname);
-        
+
         if (isProfileImageEmpty && isNicknameEmpty) {
             throw new GlobalException(ErrorCode.INFO_REQUIRED);
         }

--- a/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestStatus.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestStatus.java
@@ -1,0 +1,5 @@
+package com.potatocake.everymoment.dto.response;
+
+public enum FriendRequestStatus {
+    NONE, SENT, RECEIVED, FRIENDS, SELF
+}

--- a/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestStatus.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestStatus.java
@@ -1,5 +1,5 @@
 package com.potatocake.everymoment.dto.response;
 
 public enum FriendRequestStatus {
-    NONE, SENT, RECEIVED, FRIENDS, SELF
+    NONE, SENT, RECEIVED, FRIEND, SELF
 }

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberMyResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberMyResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class MemberResponse {
+public class MemberMyResponse {
 
     private Long id;
     private String profileImageUrl;

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResponse.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class MemberSearchResponse {
 
-    private List<MemberResponse> members;
+    private List<MemberSearchResultResponse> members;
     private Long next;
 
 }

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResultResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResultResponse.java
@@ -10,5 +10,6 @@ public class MemberSearchResultResponse {
     private Long id;
     private String profileImageUrl;
     private String nickname;
+    private FriendRequestStatus friendRequestStatus;
 
 }

--- a/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResultResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MemberSearchResultResponse.java
@@ -1,0 +1,14 @@
+package com.potatocake.everymoment.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberSearchResultResponse {
+
+    private Long id;
+    private String profileImageUrl;
+    private String nickname;
+
+}

--- a/src/main/java/com/potatocake/everymoment/repository/FriendRepository.java
+++ b/src/main/java/com/potatocake/everymoment/repository/FriendRepository.java
@@ -13,4 +13,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long>, JpaSpecif
 
     List<Friend> findFriendsByMember(Member member);
 
+    boolean existsByMemberIdAndFriendId(Long memberId, Long friendId);
+
 }

--- a/src/main/java/com/potatocake/everymoment/repository/FriendRequestRepository.java
+++ b/src/main/java/com/potatocake/everymoment/repository/FriendRequestRepository.java
@@ -1,6 +1,7 @@
 package com.potatocake.everymoment.repository;
 
 import com.potatocake.everymoment.entity.FriendRequest;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.data.domain.Window;
@@ -11,5 +12,7 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
 
     Window<FriendRequest> findByReceiverId(Long receiverId, ScrollPosition scrollPosition, Pageable pageable);
+
+    Optional<FriendRequest> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
 
 }

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -117,7 +117,7 @@ public class MemberService {
         }
 
         if (friendRepository.existsByMemberIdAndFriendId(currentMemberId, targetMemberId)) {
-            return FriendRequestStatus.FRIENDS;
+            return FriendRequestStatus.FRIEND;
         }
 
         return friendRequestRepository.findBySenderIdAndReceiverId(currentMemberId, targetMemberId)

--- a/src/main/java/com/potatocake/everymoment/service/MemberService.java
+++ b/src/main/java/com/potatocake/everymoment/service/MemberService.java
@@ -3,8 +3,9 @@ package com.potatocake.everymoment.service;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
-import com.potatocake.everymoment.dto.response.MemberResponse;
+import com.potatocake.everymoment.dto.response.MemberMyResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResultResponse;
 import com.potatocake.everymoment.entity.Member;
 import com.potatocake.everymoment.exception.ErrorCode;
 import com.potatocake.everymoment.exception.GlobalException;
@@ -33,7 +34,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberSearchResponse searchMembers(String nickname, Long key, int size) {
         Window<Member> window = fetchMemberWindow(nickname, key, size);
-        List<MemberResponse> members = convertToMemberResponses(window.getContent());
+        List<MemberSearchResultResponse> members = convertToMemberResponses(window.getContent());
         Long nextKey = pagingUtil.getNextKey(window, Member::getId);
 
         return MemberSearchResponse.builder()
@@ -55,11 +56,11 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberResponse getMemberInfo(Long memberId) {
+    public MemberMyResponse getMemberInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
-        return MemberResponse.builder()
+        return MemberMyResponse.builder()
                 .id(member.getId())
                 .profileImageUrl(member.getProfileImageUrl())
                 .nickname(member.getNickname())
@@ -94,9 +95,9 @@ public class MemberService {
         return memberRepository.findByNicknameContaining(searchNickname, scrollPosition, pageable);
     }
 
-    private List<MemberResponse> convertToMemberResponses(List<Member> members) {
+    private List<MemberSearchResultResponse> convertToMemberResponses(List<Member> members) {
         return members.stream()
-                .map(member -> MemberResponse.builder()
+                .map(member -> MemberSearchResultResponse.builder()
                         .id(member.getId())
                         .profileImageUrl(member.getProfileImageUrl())
                         .nickname(member.getNickname())

--- a/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
+++ b/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
@@ -14,8 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
+import com.potatocake.everymoment.dto.response.MemberMyResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
-import com.potatocake.everymoment.dto.response.MemberSearchResultResponse;
 import com.potatocake.everymoment.entity.Member;
 import com.potatocake.everymoment.security.MemberDetails;
 import com.potatocake.everymoment.service.MemberService;
@@ -49,12 +49,17 @@ class MemberControllerTest {
         String nickname = "testUser";
         Long key = 1L;
         int size = 10;
+
+        Long memberId = 1L;
+        MemberDetails memberDetails = createMemberDetails(memberId, 1234L, "test");
+
         MemberSearchResponse response = MemberSearchResponse.builder().build();
 
-        given(memberService.searchMembers(nickname, key, size)).willReturn(response);
+        given(memberService.searchMembers(nickname, key, size, memberId)).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/api/members")
+                .with(user(memberDetails))
                 .param("nickname", nickname)
                 .param("key", key.toString())
                 .param("size", String.valueOf(size)));
@@ -65,7 +70,7 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        then(memberService).should().searchMembers(nickname, key, size);
+        then(memberService).should().searchMembers(nickname, key, size, memberId);
     }
 
     @Test
@@ -96,7 +101,7 @@ class MemberControllerTest {
     void should_ReturnMemberInfo_When_ValidMemberId() throws Exception {
         // given
         Long memberId = 1L;
-        MemberSearchResultResponse response = MemberSearchResultResponse.builder().build();
+        MemberMyResponse response = MemberMyResponse.builder().build();
 
         given(memberService.getMemberInfo(memberId)).willReturn(response);
 

--- a/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
+++ b/src/test/java/com/potatocake/everymoment/controller/MemberControllerTest.java
@@ -14,8 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.potatocake.everymoment.dto.response.MemberDetailResponse;
-import com.potatocake.everymoment.dto.response.MemberResponse;
 import com.potatocake.everymoment.dto.response.MemberSearchResponse;
+import com.potatocake.everymoment.dto.response.MemberSearchResultResponse;
 import com.potatocake.everymoment.entity.Member;
 import com.potatocake.everymoment.security.MemberDetails;
 import com.potatocake.everymoment.service.MemberService;
@@ -96,7 +96,7 @@ class MemberControllerTest {
     void should_ReturnMemberInfo_When_ValidMemberId() throws Exception {
         // given
         Long memberId = 1L;
-        MemberResponse response = MemberResponse.builder().build();
+        MemberSearchResultResponse response = MemberSearchResultResponse.builder().build();
 
         given(memberService.getMemberInfo(memberId)).willReturn(response);
 


### PR DESCRIPTION
## 📝 작업 내용
![image](https://github.com/user-attachments/assets/06bfce29-a61f-47e4-919f-2dc23eeaf6c5)

로그인한 사용자를 기준으로 친구 요청 상태 응답에 추가

* **SELF:** 자기 자신
* **NONE:** 친구 미요청 상태
* **SENT:** 친구 요청을 보낸 상태
* **RECEIVED:** 친구 요청을 받은 상태
* **FRIEND:** 친구 상태

## 🔗 관련 이슈
close #45 
