### PR TITLE
feat: 친구 요청 목록 API에서 사용자 정보도 응답 필드에 추가

### DIFF
--- a/src/main/java/com/potatocake/everymoment/dto/request/DiaryFilterRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/DiaryFilterRequest.java
@@ -27,10 +27,11 @@ public class DiaryFilterRequest {
                 : Collections.emptyList();
     }
 
-    public List<Long> getCategories() {
+    public List<String> getCategories() {
         return (category != null && !category.isEmpty())
                 ? Arrays.stream(category.split(","))
-                .map(Long::parseLong)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList())
                 : Collections.emptyList();
     }

--- a/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
@@ -13,7 +13,5 @@ public class DiaryManualCreateRequest {
     private boolean isBookmark;
     private boolean isPublic;
     private String emoji;
-    private List<FileRequest> file;
     private String content;
 }
-

--- a/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/FriendRequestResponse.java
@@ -9,5 +9,7 @@ public class FriendRequestResponse {
 
     private Long id;
     private Long senderId;
+    private String nickname;
+    private String profileImageUrl;
 
 }

--- a/src/main/java/com/potatocake/everymoment/entity/Diary.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Diary.java
@@ -1,5 +1,6 @@
 package com.potatocake.everymoment.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +10,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,6 +56,9 @@ public class Diary extends BaseTimeEntity {
     @Column(nullable = false)
     @Builder.Default
     private boolean isPublic = false;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<DiaryCategory> diaryCategories = new HashSet<>();
 
     public void updateContent(String content) {
         if (content != null) {

--- a/src/main/java/com/potatocake/everymoment/entity/DiaryCategory.java
+++ b/src/main/java/com/potatocake/everymoment/entity/DiaryCategory.java
@@ -31,4 +31,13 @@ public class DiaryCategory {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_category_id"), nullable = false)
     private Category category;
+
+    public void setDiary(Diary diary) {
+        this.diary = diary;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
 }

--- a/src/main/java/com/potatocake/everymoment/service/DiaryService.java
+++ b/src/main/java/com/potatocake/everymoment/service/DiaryService.java
@@ -100,7 +100,6 @@ public class DiaryService {
         Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
-
         double longitude = diaryManualCreateRequest.getLocationPoint().getLongitude();
         double latitude = diaryManualCreateRequest.getLocationPoint().getLatitude();
 
@@ -149,21 +148,21 @@ public class DiaryService {
 
         Page<Diary> diaryPage;
 
-        List<Long> categoryIds = diaryFilterRequest.getCategories();
+        List<String> categories = diaryFilterRequest.getCategories();
         List<String> emojis = diaryFilterRequest.getEmojis();
 
         Specification<Diary> spec = DiarySpecification.filterDiaries(
                         diaryFilterRequest.getKeyword(),
                         emojis,
-                        categoryIds,
+                        categories,
                         diaryFilterRequest.getDate(),
                         diaryFilterRequest.getFrom(),
                         diaryFilterRequest.getUntil(),
                         diaryFilterRequest.getIsBookmark())
                 .and((root, query, builder) -> builder.equal(root.get("member"), currentMember));
 
-        diaryPage = diaryRepository.findAll(spec, PageRequest.of(diaryFilterRequest.getKey(), diaryFilterRequest.getSize()));
-
+        diaryPage = diaryRepository.findAll(spec,
+                PageRequest.of(diaryFilterRequest.getKey(), diaryFilterRequest.getSize()));
 
         List<MyDiarySimpleResponse> diaryDTOs = diaryPage.getContent().stream()
                 .map(this::convertToMyDiarySimpleResponseDto)

--- a/src/main/java/com/potatocake/everymoment/service/DiarySpecification.java
+++ b/src/main/java/com/potatocake/everymoment/service/DiarySpecification.java
@@ -1,22 +1,23 @@
 package com.potatocake.everymoment.service;
 
 
+import com.potatocake.everymoment.entity.Category;
 import com.potatocake.everymoment.entity.Diary;
 import com.potatocake.everymoment.entity.DiaryCategory;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.domain.Specification;
-
-import java.time.LocalDate;
 
 public class DiarySpecification {
 
     public static Specification<Diary> filterDiaries(
-            String keyword, List<String> emojis, List<Long> categories,
+            String keyword, List<String> emojis, List<String> categories,
             LocalDate date, LocalDate from, LocalDate until, Boolean isBookmark) {
         return (Root<Diary> root, CriteriaQuery<?> query, CriteriaBuilder builder) -> {
             Predicate predicate = builder.conjunction();
@@ -29,15 +30,17 @@ public class DiarySpecification {
             }
 
             if (categories != null && !categories.isEmpty()) {
-                Join<Diary, DiaryCategory> diaryCategoryJoin = root.join("diaryCategories");
-                predicate = builder.and(predicate, diaryCategoryJoin.get("category").get("id").in(categories));
+                Join<Diary, DiaryCategory> diaryCategoryJoin = root.join("diaryCategories", JoinType.LEFT);
+                Join<DiaryCategory, Category> categoryJoin = diaryCategoryJoin.join("category", JoinType.LEFT);
+                predicate = builder.and(predicate, categoryJoin.get("categoryName").in(categories));
             }
 
             LocalDate filterDate = (date != null) ? date : LocalDate.now();
             predicate = builder.and(predicate, builder.equal(root.get("createAt").as(LocalDate.class), filterDate));
 
             if (from != null && until != null) {
-                predicate = builder.and(predicate, builder.between(root.get("createAt"), from.atStartOfDay(), until.plusDays(1).atStartOfDay()));
+                predicate = builder.and(predicate,
+                        builder.between(root.get("createAt"), from.atStartOfDay(), until.plusDays(1).atStartOfDay()));
             }
             if (isBookmark != null) {
                 predicate = builder.and(predicate, builder.equal(root.get("isBookmark"), isBookmark));

--- a/src/main/java/com/potatocake/everymoment/service/FriendDiaryService.java
+++ b/src/main/java/com/potatocake/everymoment/service/FriendDiaryService.java
@@ -53,20 +53,21 @@ public class FriendDiaryService {
         Page<Diary> diaryPage;
 
         // 카테고리와 이모지가 여러 개 전달될 수 있으므로 이를 리스트로 변환
-        List<Long> categoryIds = diaryFilterRequest.getCategories();
+        List<String> categories = diaryFilterRequest.getCategories();
         List<String> emojis = diaryFilterRequest.getEmojis();
 
         Specification<Diary> spec = DiarySpecification.filterDiaries(
                         diaryFilterRequest.getKeyword(),
                         emojis,
-                        categoryIds,
+                        categories,
                         diaryFilterRequest.getDate(),
                         diaryFilterRequest.getFrom(),
                         diaryFilterRequest.getUntil(),
                         diaryFilterRequest.getIsBookmark())
                 .and((root, query, builder) -> root.get("member").in(friendIdList));
 
-        diaryPage = diaryRepository.findAll(spec, PageRequest.of(diaryFilterRequest.getKey(), diaryFilterRequest.getSize()));
+        diaryPage = diaryRepository.findAll(spec,
+                PageRequest.of(diaryFilterRequest.getKey(), diaryFilterRequest.getSize()));
 
         List<FriendDiarySimpleResponse> friendDiarySimpleResponseList = diaryPage.getContent().stream()
                 .map(this::convertToFriendDiariesResponseDTO)


### PR DESCRIPTION
## 📝 작업 내용
* 친구 요청을 보낸 회원의 닉네임 및 프로필 이미지 응답 필드에 추가

## 🔗 관련 이슈
close #55 

