### PR TITLE
fix: 친구 일기 조회 API 에러 수정

### DIFF
--- a/src/main/java/com/potatocake/everymoment/entity/Diary.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Diary.java
@@ -1,6 +1,5 @@
 package com.potatocake.everymoment.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -57,7 +56,7 @@ public class Diary extends BaseTimeEntity {
     @Builder.Default
     private boolean isPublic = false;
 
-    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "diary")
     private Set<DiaryCategory> diaryCategories = new HashSet<>();
 
     public void updateContent(String content) {

--- a/src/main/java/com/potatocake/everymoment/service/FriendDiaryService.java
+++ b/src/main/java/com/potatocake/everymoment/service/FriendDiaryService.java
@@ -47,7 +47,7 @@ public class FriendDiaryService {
 
         List<Friend> friends = friendRepository.findFriendsByMember(currentMember);
         List<Long> friendIdList = friends.stream()
-                .map(Friend::getId)
+                .map(friend -> friend.getFriend().getId())
                 .collect(Collectors.toList());
 
         Page<Diary> diaryPage;
@@ -64,7 +64,7 @@ public class FriendDiaryService {
                         diaryFilterRequest.getFrom(),
                         diaryFilterRequest.getUntil(),
                         diaryFilterRequest.getIsBookmark())
-                .and((root, query, builder) -> root.get("member").in(friendIdList));
+                .and((root, query, builder) -> root.get("member").get("id").in(friendIdList));
 
         diaryPage = diaryRepository.findAll(spec,
                 PageRequest.of(diaryFilterRequest.getKey(), diaryFilterRequest.getSize()));
@@ -92,10 +92,10 @@ public class FriendDiaryService {
 
         List<Friend> friends = friendRepository.findFriendsByMember(currentMember);
         List<Long> friendIdList = friends.stream()
-                .map(Friend::getId)
+                .map(friend -> friend.getFriend().getId())
                 .collect(Collectors.toList());
 
-        if (!friendIdList.contains(diary.getMember())) {
+        if (!friendIdList.contains(diary.getMember().getId())) {
             throw new GlobalException(ErrorCode.FRIEND_NOT_FOUND);
         }
 
@@ -151,4 +151,5 @@ public class FriendDiaryService {
                 .createAt(savedDiary.getCreateAt())
                 .build();
     }
+    
 }


### PR DESCRIPTION
## 📝 작업 내용
* 친구 일기 조회 시 id 비교 에러 수정
  * id끼리 비교해야 하는데, 엔티티와 id를 비교하여 에러 발생

## 🔗 관련 이슈
close #61 
