### PR TITLE
feat: 파일 수정 API에서 파일을 첨부하지 않아도 되도록 수정

### DIFF
--- a/src/main/java/com/potatocake/everymoment/controller/CommentController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/CommentController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,7 +36,7 @@ public class CommentController {
             @Parameter(description = "수정할 댓글 ID", required = true)
             @PathVariable Long commentId,
             @Parameter(description = "댓글 수정 정보", required = true)
-            @RequestBody CommentRequest commentRequest) {
+            @RequestBody @Valid CommentRequest commentRequest) {
         Long memberId = memberDetails.getId();
 
         commentService.updateComment(memberId, commentId, commentRequest);

--- a/src/main/java/com/potatocake/everymoment/controller/DiaryController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/DiaryController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -309,7 +310,7 @@ public class DiaryController {
             @Parameter(description = "댓글을 작성할 일기 ID", required = true)
             @PathVariable Long diaryId,
             @Parameter(description = "댓글 작성 정보", required = true)
-            @RequestBody CommentRequest commentRequest) {
+            @RequestBody @Valid CommentRequest commentRequest) {
         Long memberId = memberDetails.getId();
 
         commentService.createComment(memberId, diaryId, commentRequest);

--- a/src/main/java/com/potatocake/everymoment/controller/FileController.java
+++ b/src/main/java/com/potatocake/everymoment/controller/FileController.java
@@ -71,8 +71,8 @@ public class FileController {
             @PathVariable Long diaryId,
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal MemberDetails memberDetails,
-            @Parameter(description = "수정할 파일 목록", required = true)
-            @RequestPart List<MultipartFile> files
+            @Parameter(description = "수정할 파일 목록")
+            @RequestPart(required = false) List<MultipartFile> files
     ) {
         fileService.updateFiles(diaryId, memberDetails.getId(), files);
 

--- a/src/main/java/com/potatocake/everymoment/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/CategoryCreateRequest.java
@@ -3,14 +3,14 @@ package com.potatocake.everymoment.dto.request;
 import com.potatocake.everymoment.entity.Category;
 import com.potatocake.everymoment.entity.Member;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 @Getter
 public class CategoryCreateRequest {
 
-    @Length(max = 50)
-    @NotEmpty
+    @Size(max = 50, message = "카테고리명은 50자를 초과할 수 없습니다")
+    @NotEmpty(message = "카테고리명은 필수입니다")
     private String categoryName;
 
     public Category toEntity(Member member) {

--- a/src/main/java/com/potatocake/everymoment/dto/request/CommentRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/CommentRequest.java
@@ -1,12 +1,14 @@
 package com.potatocake.everymoment.dto.request;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class CommentRequest {
 
-    @NotEmpty(message = "댓글 내용을 입력해 주세요.")
+    @NotBlank(message = "댓글 내용은 필수입니다")
+    @Size(max = 250, message = "댓글은 250자를 초과할 수 없습니다")
     private String content;
 
 }

--- a/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
@@ -15,7 +15,7 @@ public class DiaryManualCreateRequest {
     @Size(max = 50, message = "장소명은 50자를 초과할 수 없습니다")
     private String locationName;
 
-    @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다")
+    @Size(max = 250, message = "주소는 250자를 초과할 수 없습니다")
     private String address;
 
     private boolean isBookmark;
@@ -24,7 +24,7 @@ public class DiaryManualCreateRequest {
     @Size(max = 10, message = "이모지는 10자를 초과할 수 없습니다")
     private String emoji;
 
-    @Size(max = 5000, message = "일기 내용은 5000자를 초과할 수 없습니다")
+    @Size(max = 15000, message = "일기 내용은 15,000자를 초과할 수 없습니다")
     private String content;
 
 }

--- a/src/main/java/com/potatocake/everymoment/dto/request/DiaryPatchRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/DiaryPatchRequest.java
@@ -1,6 +1,5 @@
 package com.potatocake.everymoment.dto.request;
 
-import com.potatocake.everymoment.dto.LocationPoint;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
@@ -25,7 +24,7 @@ public class DiaryPatchRequest {
     @Size(max = 10, message = "이모지는 10자를 초과할 수 없습니다")
     private String emoji;
 
-    @Size(max = 5000, message = "일기 내용은 5000자를 초과할 수 없습니다")
+    @Size(max = 15000, message = "일기 내용은 15,000자를 초과할 수 없습니다")
     private String content;
 
 }

--- a/src/main/java/com/potatocake/everymoment/dto/request/FcmTokenRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/FcmTokenRequest.java
@@ -1,15 +1,18 @@
 package com.potatocake.everymoment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class FcmTokenRequest {
 
     @NotBlank(message = "FCM 토큰은 필수입니다.")
+    @Size(max = 512, message = "FCM 토큰은 512자를 넘을 수 없습니다.")
     private String fcmToken;
 
     @NotBlank(message = "디바이스 ID는 필수입니다.")
+    @Size(max = 512, message = "디바이스 ID는 512자를 넘을 수 없습니다.")
     private String deviceId;
 
 }

--- a/src/main/java/com/potatocake/everymoment/entity/Comment.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.potatocake.everymoment.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Builder
-public class Comment extends BaseTimeEntity{
+public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,6 +34,7 @@ public class Comment extends BaseTimeEntity{
     private Diary diary;
 
     @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     public void updateContent(String content) {

--- a/src/main/java/com/potatocake/everymoment/entity/DeviceToken.java
+++ b/src/main/java/com/potatocake/everymoment/entity/DeviceToken.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,11 +26,10 @@ public class DeviceToken extends BaseTimeEntity {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @Column(nullable = false)
+    @Column(length = 512, nullable = false)
     private String fcmToken;
 
-    @Column(nullable = false)
-    @Lob
+    @Column(length = 512, nullable = false)
     private String deviceId;
 
     @Builder

--- a/src/main/java/com/potatocake/everymoment/entity/Diary.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Diary.java
@@ -34,7 +34,7 @@ public class Diary extends BaseTimeEntity {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)
@@ -43,7 +43,7 @@ public class Diary extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     private String locationName;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 250, nullable = false)
     private String address;
 
     @Lob

--- a/src/main/java/com/potatocake/everymoment/entity/File.java
+++ b/src/main/java/com/potatocake/everymoment/entity/File.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,7 +24,7 @@ public class File extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Diary diary;
 
-    @Lob
+    @Column(length = 2083, nullable = false)
     private String imageUrl;
 
     @Column(name = "\"order\"")

--- a/src/main/java/com/potatocake/everymoment/entity/Member.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Member.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,7 +34,7 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false, length = 50)
     private String nickname;
 
-    @Lob
+    @Column(length = 2083, nullable = false)
     private String profileImageUrl;
 
     @Column(nullable = false)

--- a/src/main/java/com/potatocake/everymoment/service/FileService.java
+++ b/src/main/java/com/potatocake/everymoment/service/FileService.java
@@ -64,7 +64,9 @@ public class FileService {
 
         fileRepository.deleteByDiary(diary);
 
-        uploadFiles(diaryId, memberId, files);
+        if (files != null && !files.isEmpty()) {
+            uploadFiles(diaryId, memberId, files);
+        }
     }
 
 }


### PR DESCRIPTION
## 📝 작업 내용
* 아무 파일도 첨부하지 않으면, 단순히 일기에 연관된 파일 모두 삭제
* 컬럼 최대 데이터 크기 지정

## 🔗 관련 이슈
close #75 
