### PR TITLE
feat: 개별 파일 용량 최대 5MB, 총 용량 25MB로 증진

### DIFF
--- a/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
+++ b/src/main/java/com/potatocake/everymoment/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
 
     /* File */
     FILE_NOT_FOUND("존재하지 않는 파일입니다.", NOT_FOUND),
-    FILE_SIZE_EXCEEDED("각 파일은 1MB 이하로, 전체 파일 크기는 10MB 이하로 첨부해 주세요.", PAYLOAD_TOO_LARGE),
+    FILE_SIZE_EXCEEDED("각 파일은 5MB 이하로, 전체 파일 크기는 25MB 이하로 첨부해 주세요.", PAYLOAD_TOO_LARGE),
 
     /* Comment */
     COMMENT_NOT_FOUND("존재하지 않는 댓글입니다.", NOT_FOUND),

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,8 +20,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 1MB
-      max-request-size: 10MB
+      max-file-size: 5MB
+      max-request-size: 25MB
       resolve-lazily: true
 
 aws:


### PR DESCRIPTION
## 📝 작업 내용
* 기존 1MB, 10MB -> 5MB, 25MB

## 🔗 관련 이슈
close #87 
