### PR TITLE
feat: 수기일기 수정, 알람 조회순 변경

### DIFF
--- a/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
+++ b/src/main/java/com/potatocake/everymoment/dto/request/DiaryManualCreateRequest.java
@@ -3,6 +3,7 @@ package com.potatocake.everymoment.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.potatocake.everymoment.dto.LocationPoint;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,8 @@ import lombok.Getter;
 @Builder
 @Getter
 public class DiaryManualCreateRequest {
+
+    private LocalDate diaryDate;
 
     private List<CategoryRequest> categories;
 

--- a/src/main/java/com/potatocake/everymoment/dto/response/MyDiaryResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MyDiaryResponse.java
@@ -1,5 +1,6 @@
 package com.potatocake.everymoment.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -17,4 +18,5 @@ public class MyDiaryResponse {
     private String content;
     private boolean isLiked;
     private LocalDateTime createAt;
+    private LocalDate diaryDate;
 }

--- a/src/main/java/com/potatocake/everymoment/dto/response/MyDiarySimpleResponse.java
+++ b/src/main/java/com/potatocake/everymoment/dto/response/MyDiarySimpleResponse.java
@@ -1,5 +1,6 @@
 package com.potatocake.everymoment.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +17,5 @@ public class MyDiarySimpleResponse {
     private ThumbnailResponse thumbnailResponse;
     private String content;
     private LocalDateTime createAt;
+    private LocalDate diaryDate;
 }

--- a/src/main/java/com/potatocake/everymoment/entity/Diary.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Diary.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AccessLevel;
@@ -36,6 +37,9 @@ public class Diary extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @Column
+    private LocalDate diaryDate;
 
     @Column(nullable = false)
     private Point locationPoint;

--- a/src/main/java/com/potatocake/everymoment/repository/NotificationRepository.java
+++ b/src/main/java/com/potatocake/everymoment/repository/NotificationRepository.java
@@ -2,8 +2,11 @@ package com.potatocake.everymoment.repository;
 
 import com.potatocake.everymoment.entity.Notification;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findAllByMemberId(Long memberId);
+
+    List<Notification> findAllByMemberId(Long memberId, Sort sort);
+
 }

--- a/src/main/java/com/potatocake/everymoment/service/DiaryService.java
+++ b/src/main/java/com/potatocake/everymoment/service/DiaryService.java
@@ -95,6 +95,7 @@ public class DiaryService {
         Diary diary = Diary.builder()
                 .member(currentMember)
                 .content(diaryManualCreateRequest.getContent())
+                .diaryDate(diaryManualCreateRequest.getDiaryDate())
                 .locationPoint(point)
                 .locationName(diaryManualCreateRequest.getLocationName())
                 .address(diaryManualCreateRequest.getAddress())
@@ -295,6 +296,7 @@ public class DiaryService {
                 .content(savedDiary.getContent())
                 .isLiked(isLiked)
                 .createAt(savedDiary.getCreateAt())
+                .diaryDate(savedDiary.getDiaryDate())
                 .build();
     }
 
@@ -319,6 +321,7 @@ public class DiaryService {
                 .thumbnailResponse(thumbnailResponse)
                 .content(savedDiary.getContent())
                 .createAt(savedDiary.getCreateAt())
+                .diaryDate(savedDiary.getDiaryDate())
                 .build();
     }
 }

--- a/src/main/java/com/potatocake/everymoment/service/DiaryService.java
+++ b/src/main/java/com/potatocake/everymoment/service/DiaryService.java
@@ -107,22 +107,8 @@ public class DiaryService {
 
         //카테고리 저장
         List<CategoryRequest> categoryRequestList = diaryManualCreateRequest.getCategories();
-        for (CategoryRequest categoryRequest : categoryRequestList) {
-            Long categoryId = categoryRequest.getCategoryId();
-
-            DiaryCategory diaryCategory = DiaryCategory.builder()
-                    .diary(savedDiary)
-                    .category(categoryRepository.findById(categoryId)
-                            .map(category -> {
-                                // Category가 현재 사용자의 소유인지 확인
-                                category.checkOwner(currentMember.getId());
-                                return category;
-                            })
-                            .orElseThrow(() -> new GlobalException(ErrorCode.CATEGORY_NOT_FOUND)))
-                    .build();
-
-            diaryCategoryRepository.save(diaryCategory);
-
+        if(categoryRequestList != null){
+            addDiaryCategory(savedDiary, currentMember.getId(), categoryRequestList);
         }
     }
 
@@ -140,7 +126,7 @@ public class DiaryService {
 
         Specification<Diary> spec;
 
-        if (!diaryFilterRequest.hasFilter()) {
+        if(!diaryFilterRequest.hasFilter()){
             LocalDate today = LocalDate.now();
 
             spec = DiarySpecification.filterDiaries(
@@ -213,22 +199,7 @@ public class DiaryService {
 
             if (categoryRequestList != null && !categoryRequestList.isEmpty()) {
                 diaryCategoryRepository.deleteByDiary(existingDiary);
-
-                for (CategoryRequest categoryRequest : categoryRequestList) {
-                    Long categoryId = categoryRequest.getCategoryId();
-
-                    DiaryCategory diaryCategory = DiaryCategory.builder()
-                            .diary(existingDiary)
-                            .category(categoryRepository.findById(categoryId)
-                                    .map(category -> {
-                                        category.checkOwner(memberId);
-                                        return category;
-                                    })
-                                    .orElseThrow(() -> new GlobalException(ErrorCode.CATEGORY_NOT_FOUND)))
-                            .build();
-
-                    diaryCategoryRepository.save(diaryCategory);
-                }
+                addDiaryCategory(existingDiary, memberId, categoryRequestList);
             }
         }
 
@@ -280,6 +251,25 @@ public class DiaryService {
         }
 
         return diary;
+    }
+
+    //다이어리에 카테고리 추가
+    private void addDiaryCategory(Diary savedDiary, Long memberId, List<CategoryRequest> categoryRequestList) {
+        for (CategoryRequest categoryRequest : categoryRequestList) {
+            Long categoryId = categoryRequest.getCategoryId();
+
+            DiaryCategory diaryCategory = DiaryCategory.builder()
+                    .diary(savedDiary)
+                    .category(categoryRepository.findById(categoryId)
+                            .map(category -> {
+                                category.checkOwner(memberId);
+                                return category;
+                            })
+                            .orElseThrow(() -> new GlobalException(ErrorCode.CATEGORY_NOT_FOUND)))
+                    .build();
+
+            diaryCategoryRepository.save(diaryCategory);
+        }
     }
 
     //상세 조회시 일기DTO 변환

--- a/src/main/java/com/potatocake/everymoment/service/DiarySpecification.java
+++ b/src/main/java/com/potatocake/everymoment/service/DiarySpecification.java
@@ -37,12 +37,31 @@ public class DiarySpecification {
             }
 
             if(date != null){
-                predicate = builder.and(predicate, builder.equal(root.get("createAt").as(LocalDate.class), date));
+                predicate = builder.and(predicate,
+                        builder.or(
+                                builder.and(
+                                        builder.isNotNull(root.get("diaryDate")),
+                                        builder.equal(root.get("diaryDate"), date)
+                                ),
+                                builder.and(
+                                        builder.isNull(root.get("diaryDate")),
+                                        builder.equal(root.get("createAt").as(LocalDate.class), date)
+                                )
+                        ));
             }
 
             if (from != null && until != null) {
                 predicate = builder.and(predicate,
-                        builder.between(root.get("createAt"), from, until.plusDays(1)));
+                        builder.or(
+                                builder.and(
+                                        builder.isNotNull(root.get("diaryDate")),
+                                        builder.between(root.get("diaryDate"), from, until)
+                                ),
+                                builder.and(
+                                        builder.isNull(root.get("diaryDate")),
+                                        builder.between(root.get("createAt"), from, until.plusDays(1))
+                                )
+                        ));
             }
 
             if (isBookmark != null) {

--- a/src/main/java/com/potatocake/everymoment/service/NotificationService.java
+++ b/src/main/java/com/potatocake/everymoment/service/NotificationService.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,7 +61,8 @@ public class NotificationService {
         Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
-        List<Notification> notifications = notificationRepository.findAllByMemberId(currentMember.getId());
+        List<Notification> notifications = notificationRepository.findAllByMemberId(
+                currentMember.getId(), Sort.by(Sort.Direction.DESC, "createAt"));
 
         return notifications.stream()
                 .map(this::convertToNotificationResponseDTO)

--- a/src/test/java/com/potatocake/everymoment/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/potatocake/everymoment/repository/NotificationRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
@@ -79,7 +80,7 @@ class NotificationRepositoryTest {
 
         // when
         List<Notification> foundNotifications = notificationRepository
-                .findAllByMemberId(savedMember.getId());
+                .findAllByMemberId(savedMember.getId(), Sort.by(Sort.Direction.DESC, "createAt"));
 
         // then
         assertThat(foundNotifications).hasSize(2);
@@ -113,7 +114,7 @@ class NotificationRepositoryTest {
 
         // then
         List<Notification> remainingNotifications = notificationRepository
-                .findAllByMemberId(savedMember.getId());
+                .findAllByMemberId(savedMember.getId(), Sort.by(Sort.Direction.DESC, "createAt"));
         assertThat(remainingNotifications).isEmpty();
     }
 

--- a/src/test/java/com/potatocake/everymoment/service/NotificationServiceTest.java
+++ b/src/test/java/com/potatocake/everymoment/service/NotificationServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -104,7 +105,7 @@ class NotificationServiceTest {
         );
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(notificationRepository.findAllByMemberId(memberId)).willReturn(notifications);
+        given(notificationRepository.findAllByMemberId(memberId, Sort.by(Sort.Direction.DESC, "createAt"))).willReturn(notifications);
 
         // when
         List<NotificationListResponse> responses = notificationService.getNotifications(memberId);


### PR DESCRIPTION
## 📝 작업 내용
수기 일기 카테고리 없이 저장안되는 오류 수정
수기 일기에 일기 날짜(diaryDate)추가
알림 최신순으로 변경

## 🔗 관련 이슈
close #104 
