### PR TITLE
fix: 좋아요 데이터 동시성 제어

### DIFF
--- a/src/main/java/com/potatocake/everymoment/entity/Like.java
+++ b/src/main/java/com/potatocake/everymoment/entity/Like.java
@@ -7,12 +7,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "diary_id"})
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/src/main/java/com/potatocake/everymoment/repository/LikeRepository.java
+++ b/src/main/java/com/potatocake/everymoment/repository/LikeRepository.java
@@ -2,12 +2,18 @@ package com.potatocake.everymoment.repository;
 
 import com.potatocake.everymoment.entity.Diary;
 import com.potatocake.everymoment.entity.Like;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    Optional<Like> findByMemberIdAndDiaryId(Long memberId, Long diaryId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT l FROM Like l WHERE l.member.id = :memberId AND l.diary.id = :diaryId")
+    Optional<Like> findByMemberIdAndDiaryIdWithLock(@Param("memberId") Long memberId, @Param("diaryId") Long diaryId);
 
     Long countByDiary(Diary diary);
 

--- a/src/main/java/com/potatocake/everymoment/service/LikeService.java
+++ b/src/main/java/com/potatocake/everymoment/service/LikeService.java
@@ -48,7 +48,7 @@ public class LikeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Optional<Like> existingLike = likeRepository.findByMemberIdAndDiaryId(memberId, diaryId);
+        Optional<Like> existingLike = likeRepository.findByMemberIdAndDiaryIdWithLock(memberId, diaryId);
 
         if (existingLike.isPresent()) {
             // 이미 좋아요가 존재하면 삭제 (좋아요 취소)


### PR DESCRIPTION
## 📝 작업 내용
* 유니크 제약조건 추가 (member_id, diary_id)
* 비관적 락으로 동시성 제어

## 🔗 관련 이슈
close #106 

